### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,5 +1,8 @@
 name: Go-Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/dark-person/lazydb/security/code-scanning/1](https://github.com/dark-person/lazydb/security/code-scanning/1)

To fix the issue, an explicit `permissions` block should be added to the workflow file. It can be added either at the workflow level (top-level, affects all jobs) or at the job level (inside a specific job, overrides workflow defaults). For minimal privilege, set `contents: read` at the top level, which is sufficient for checking out code and running tests. Edit `.github/workflows/go-test.yml` to add a permissions block after the `name` and before the `jobs:` keyword. No imports, definitions, or method changes are necessary; just a YAML block addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
